### PR TITLE
Add cmake to dependency lists.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You will need to install the following dependencies to be able to run this scrip
 sudo apt install build-essential clang bison flex libreadline-dev gawk \
                  tcl-dev libffi-dev git mercurial graphviz xdot pkg-config \
                  python python3 libftdi-dev qt5-default libqt5opengl5-dev \
-                 python3-dev libboost-all-dev git
+                 python3-dev libboost-all-dev git cmake
 ```
 
 ### Mac OS

--- a/summon-fpga-tools.sh
+++ b/summon-fpga-tools.sh
@@ -17,7 +17,7 @@
 #
 # apt-get install flex bison libgmp3-dev libmpfr-dev libncurses5-dev \
 # libmpc-dev autoconf texinfo build-essential libftdi-dev zlib1g-dev git \
-# gperf
+# gperf cmake
 #
 # Or on Ubuntu Maverick give `apt-get build-dep gcc-4.5` a try.
 #


### PR DESCRIPTION
Working on a new Raspbian installation, found that cmake is needed but not listed as a dependency.