### PR TITLE
Add prjtrellis, nextpnr ECP5 target

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ This repository contains a simple but flexible script that builds a open-source 
 * Yosys
 * prjtrellis
 * nextpnr-ice40
+* nextpnr-ecp5
 * arachne-pnr
 * icestorm
 * icarus-verilog
 
 More tools will be added over time. The current candidates are:
 
-* nextpnr-ecp5
 * verilator
 * gtkwave
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This repository contains a simple but flexible script that builds a open-source FPGA tools. These tools consist from:
 
 * Yosys
+* prjtrellis
 * nextpnr-ice40
 * arachne-pnr
 * icestorm
@@ -10,7 +11,6 @@ This repository contains a simple but flexible script that builds a open-source 
 
 More tools will be added over time. The current candidates are:
 
-* prj-trellis
 * nextpnr-ecp5
 * verilator
 * gtkwave

--- a/summon-fpga-tools.sh
+++ b/summon-fpga-tools.sh
@@ -45,6 +45,8 @@ QUIET=0
 # Set to 'master' or a git revision number to use instead of stable version
 ICESTORM_EN=1
 ICESTORM_GIT=master
+PRJTRELLIS_EN=1
+PRJTRELLIS_GIT=master
 ARACHNEPNR_EN=1
 ARACHNEPNR_GIT=master
 NEXTPNR_EN=1
@@ -80,6 +82,9 @@ while [ $# -gt 0 ]; do
 		ICESTORM_GIT=*)
 		ICESTORM_GIT=$(echo $1 | sed 's,^ICESTORM_GIT=,,')
 		;;
+		PRJTRELLIS_GIT=*)
+		PRJTRELLIS_GIT=$(echo $1 | sed 's,^PRJTRELLIS_GIT=,,')
+		;;
 		ARACHNEPNR_GIT=*)
 		ARACHNEPNR_GIT=$(echo $1 | sed 's,^ARACHNEPNR_GIT=,,')
 		;;
@@ -112,6 +117,7 @@ done
 ##############################################################################
 
 DEFAULT_ICESTORM=
+DEFAULT_PRJTRELLIS=
 DEFAULT_ARACHNEPNR=
 DEFAULT_NEXTPNR=
 DEFAULT_YOSYS=yosys-0.8
@@ -119,6 +125,7 @@ DEFAULT_IVERILOG_VERSION=v10_2
 DEFAULT_IVERILOG=iverilog-${DEFAULT_IVERILOG_VERSION}
 
 ICESTORM=${ICESTORM:-${DEFAULT_ICESTORM}}
+PRJTRELLIS=${PRJTRELLIS:-${DEFAULT_PRJTRELLIS}}
 ARACHNEPNR=${ARACHNEPNR:-${DEFAULT_ARACHNEPNR}}
 NEXTPNR=${NEXTPNR:-${DEFAULT_NEXTPNR}}
 YOSYS=${YOSYS:-${DEFAULT_YOSYS}}${IVERILOG}
@@ -135,6 +142,8 @@ echo "SUDO=$SUDO"
 echo "QUIET=$QUIET"
 echo "ICESTORM=$ICESTORM"
 echo "ICESTORM_GIT=$ICESTORM_GIT"
+echo "PRJTRELLIS=$PRJTRELLIS"
+echo "PRJTRELLIS_GIT=$PRJTRELLIS_GIT"
 echo "ARACHNEPNR=$ARACHNEPNR"
 echo "ARACHNEPNR_GIT=$ARACHNEPNR_GIT"
 echo "NEXTPNR=$NEXTPNR"
@@ -165,6 +174,7 @@ fi
 echo "${CPUS} cpu's detected running make with '${PARALLEL}' flag"
 
 ICESTORMFLAGS=
+PRJTRELLISFLAGS=
 ARACHNEPNRFLAGS=
 NEXTPNRFLAGS=
 YOSYSFLAGS=
@@ -340,6 +350,16 @@ if [ ${ICESTORM_EN} != 0 ]; then
 	fi
 fi
 
+if [ ${PRJTRELLIS_EN} != 0 ]; then
+	if [ "x${PRJTRELLIS_GIT}" == "x" ]; then
+		log "There is no prjtrellis stable release download server yet!"
+		exit 1
+		#fetch ${PRJTRELLIS} https://github.com/SymbiFlow/prjtrellis/archive/${PRJTRELLIS}.tar.bz2
+	else
+		clone prjtrellis ${PRJTRELLIS_GIT} git://github.com/SymbiFlow/prjtrellis.git
+	fi
+fi
+
 if [ ${ARACHNEPNR_EN} != 0 ]; then
 	if [ "x${ARACHNEPNR_GIT}" == "x" ]; then
 		log "There is no arachne-pnr stable release download server yet!"
@@ -396,6 +416,20 @@ if [ ! -e ${STAMPS}/${ICESTORM}.build ]; then
     log "Cleaning up ${ICESTORM}"
     touch ${STAMPS}/${ICESTORM}.build
     rm -rf ${ICESTORM}
+fi
+
+if [ ! -e ${STAMPS}/${PRJTRELLIS}.build ]; then
+    unpack ${PRJTRELLIS}
+    cd ${PRJTRELLIS}/libtrellis
+    log "Configuring ${PRJTRELLIS}"
+    cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} .
+    log "Building ${PRJTRELLIS}"
+    make ${MAKEFLAGS}
+    install ${PRJTRELLIS} install
+    cd ../..
+    log "Cleaning up ${PRJTRELLIS}"
+    touch ${STAMPS}/${PRJTRELLIS}.build
+    rm -rf build/* ${PRJTRELLIS}
 fi
 
 if [ ! -e ${STAMPS}/${ARACHNEPNR}.build ]; then

--- a/summon-fpga-tools.sh
+++ b/summon-fpga-tools.sh
@@ -49,7 +49,8 @@ PRJTRELLIS_EN=1
 PRJTRELLIS_GIT=master
 ARACHNEPNR_EN=1
 ARACHNEPNR_GIT=master
-NEXTPNR_EN=1
+NEXTPNR_ICE40_EN=1
+NEXTPNR_ECP5_EN=1
 NEXTPNR_GIT=master
 NEXTPNR_BUILD_GUI=on
 YOSYS_EN=1
@@ -370,9 +371,9 @@ if [ ${ARACHNEPNR_EN} != 0 ]; then
 	fi
 fi
 
-if [ ${NEXTPNR_EN} != 0 ]; then
+if [ ${NEXTPNR_ICE40_EN} != 0 ] || [ ${NEXTPNR_ECP5_EN} != 0 ]; then
 	if [ "x${NEXTPNR_GIT}" == "x" ]; then
-		log "There is no arachne-pnr stable release download server yet!"
+		log "There is no nextpnr stable release download server yet!"
 		exit 1
 		#fetch ${NEXTPNR} https://github.com/YosysHQ/nextpnr/archive/${NEXTPNR}.tar.bz2
 	else
@@ -447,17 +448,18 @@ fi
 if [ ! -e ${STAMPS}/${NEXTPNR}.build ]; then
     unpack ${NEXTPNR}
     cd build
-    log "Configuring ${NEXTPNR}-ice40"
+    log "Configuring ${NEXTPNR}"
     CMAKE_PREFIX_PATH=${QT5_PREFIX:-${QT5_PREFIX}/lib/cmake/Qt5}
-    cmake -DARCH=ice40 -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-    	-DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH} \
-	-DBUILD_GUI=${NEXTPNR_BUILD_GUI} \
-    	-DICEBOX_ROOT=${PREFIX}/share/icebox ../${NEXTPNR}
-    log "Building ${NEXTPNR}-ice40"
+    cmake -DARCH="ice40;ecp5" -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+        -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH} \
+        -DBUILD_GUI=${NEXTPNR_BUILD_GUI} \
+        -DTRELLIS_ROOT=${PREFIX} \
+        -DICEBOX_ROOT=${PREFIX}/share/icebox ../${NEXTPNR}
+    log "Building ${NEXTPNR}"
     make ${MAKEFLAGS}
     install ${NEXTPNR} install
     cd ..
-    log "Cleaning up ${NEXTPNR}-ice40"
+    log "Cleaning up ${NEXTPNR}"
     touch ${STAMPS}/${NEXTPNR}.build
     rm -rf build/* ${NEXTPNR}
 fi

--- a/summon-fpga-tools.sh
+++ b/summon-fpga-tools.sh
@@ -274,7 +274,7 @@ function clone {
             rm -rf ${NAME}-${GIT_SHA}
         fi
         log "Cloning ${NAME}-${GIT_SHA} ..."
-        git clone ${GIT_URL} ${NAME}-${GIT_SHA}
+        git clone --recursive ${GIT_URL} ${NAME}-${GIT_SHA}
         cd ${NAME}-${GIT_SHA}
         log "Checking out the revision ${GIT_REF} with the SHA ${GIT_SHA} ..."
         git checkout -b sft-branch ${GIT_SHA}


### PR DESCRIPTION
This will need review and enhancement, as I default to building ECP5 stuff. I also don't know enough bash to build a proper target list for nextpnr CMake from the ICE40_EN and ECP5_EN variables I introduced. There's also a pull request for nextpnr, to fix a difference in interpretation of TRELLIS_ROOT between prjtrellis and nextpnr. This PR depends on that PR being accepted.