### PR TITLE
fix build error with libtrellis missing version.cpp

### DIFF
--- a/summon-fpga-tools.sh
+++ b/summon-fpga-tools.sh
@@ -391,7 +391,9 @@ if [ ! -e build ]; then
     mkdir build
 fi
 
-if [ ! -e ${STAMPS}/${ICESTORM}.build ]; then
+
+
+if [ ${ICESTORM_EN} != 0 ] && [ ! -e ${STAMPS}/${ICESTORM}.build ]; then
     unpack ${ICESTORM}
     cd ${ICESTORM}
     log "Building ${ICESTORM}"
@@ -403,7 +405,7 @@ if [ ! -e ${STAMPS}/${ICESTORM}.build ]; then
     rm -rf ${ICESTORM}
 fi
 
-if [ ! -e ${STAMPS}/${PRJTRELLIS}.build ]; then
+if [ ${PRJTRELLIS_EN} != 0 ] && [ ! -e ${STAMPS}/${PRJTRELLIS}.build ]; then
     unpack ${PRJTRELLIS}
     cd ${PRJTRELLIS}/libtrellis
     log "Configuring ${PRJTRELLIS}"
@@ -423,7 +425,7 @@ if [ ! -e ${STAMPS}/${PRJTRELLIS}.build ]; then
     rm -rf build/* ${PRJTRELLIS}
 fi
 
-if [ ! -e ${STAMPS}/${ARACHNEPNR}.build ]; then
+if [ ${ARACHNEPNR_EN} != 0 ] && [ ! -e ${STAMPS}/${ARACHNEPNR}.build ]; then
     unpack ${ARACHNEPNR}
     cd ${ARACHNEPNR}
     log "Building ${ARACHNEPNR}"
@@ -435,7 +437,7 @@ if [ ! -e ${STAMPS}/${ARACHNEPNR}.build ]; then
     rm -rf ${ARACHNEPNR}
 fi
 
-if [ ! -e ${STAMPS}/${NEXTPNR}.build ]; then
+if [ ${NEXTPNR_EN} != 0 ] && [ ! -e ${STAMPS}/${NEXTPNR}.build ]; then
     unpack ${NEXTPNR}
     cd build
     log "Configuring ${NEXTPNR}"
@@ -454,7 +456,7 @@ if [ ! -e ${STAMPS}/${NEXTPNR}.build ]; then
     rm -rf build/* ${NEXTPNR}
 fi
 
-if [ ! -e ${STAMPS}/${YOSYS}.build ]; then
+if [ ${YOSYS_EN} != 0 ] && [ ! -e ${STAMPS}/${YOSYS}.build ]; then
     unpack ${YOSYS}
     if [ "x${YOSYS_GIT}" == "x" ]; then
         cd yosys-${YOSYS}
@@ -474,7 +476,7 @@ if [ ! -e ${STAMPS}/${YOSYS}.build ]; then
     fi
 fi
 
-if [ ! -e ${STAMPS}/${IVERILOG}.build ]; then
+if [ ${IVERILOG_EN} != 0 ] && [ ! -e ${STAMPS}/${IVERILOG}.build ]; then
     unpack ${IVERILOG}
     cd ${IVERILOG}
     log "Running autogen for ${IVERILOG}"

--- a/summon-fpga-tools.sh
+++ b/summon-fpga-tools.sh
@@ -22,40 +22,41 @@ set -e
 ##############################################################################
 # Default settings section
 # You probably want to customize those
-# You can also pass them as parameters to the script
+# You can also pass them as parameters to the script or
+# override them by setting the env var before running the script
 ##############################################################################
-PREFIX=${HOME}/sft	# Install location of your final fpga tools
+PREFIX=${PREFIX:-${HOME}/sft}	# Install location of your final fpga tools
 # We do not support MacPorts only homebrew for the time being...
 #DARWIN_OPT_PATH=/usr/local	# Path in which MacPorts or Fink is installed
 # Set to 'sudo' if you need superuser privileges while installing
-SUDO=
+SUDO=${SUDO:-}
 # Set to 1 to be quieter while running
-QUIET=0
+QUIET=${QUIET:-0}
 # default to not being verbose
-VERBOSE=
+VERBOSE=${VERBOSE:-}
 # Set to 'master' or a git revision number to use instead of stable version
-ICESTORM_EN=1
-ICESTORM_GIT=master
-PRJTRELLIS_EN=1
-PRJTRELLIS_GIT=master
-ARACHNEPNR_EN=1
-ARACHNEPNR_GIT=master
-NEXTPNR_ICE40_EN=1
-NEXTPNR_ECP5_EN=1
-NEXTPNR_GIT=master
-NEXTPNR_BUILD_GUI=on
-YOSYS_EN=1
-YOSYS_GIT=master
-YOSYS_CONFIG=
-IVERILOG_EN=1
-IVERILOG_GIT=v10-branch
+ICESTORM_EN=${ICESTORM_EN:-1}
+ICESTORM_GIT=${ICESTORM_GIT:-master}
+PRJTRELLIS_EN=${PRJTRELLIS_EN:-1}
+PRJTRELLIS_GIT=${PRJTRELLIS_GIT:-master}
+ARACHNEPNR_EN=${ARACHNEPNR_EN:-1}
+ARACHNEPNR_GIT=${ARACHNEPNR_GIT:-master}
+NEXTPNR_ICE40_EN=${NEXTPNR_ICE40_EN:-1}
+NEXTPNR_ECP5_EN=${NEXTPNR_ECP5_EN:-1}
+NEXTPNR_GIT=${NEXTPNR_GIT:-master}
+NEXTPNR_BUILD_GUI=${NEXTPNR_BUILD_GUI:-on}
+YOSYS_EN=${YOSYS_EN:-1}
+YOSYS_GIT=${YOSYS_GIT:-master}
+YOSYS_CONFIG=${YOSYS_CONFIG:-}
+IVERILOG_EN=${IVERILOG_EN:-1}
+IVERILOG_GIT=${IVERILOG_GIT:-v10-branch}
 
 # Override automatic detection of cpus to compile on
-CPUS=
+CPUS=${CPUS:-}
 
 # FTP options ... some environments do not support non-passive FTP
 # FETCH_NO_PASSIVE="--no-passive-ftp "
-FETCH_NO_CERTCHECK="--no-check-certificate "
+FETCH_NO_CERTCHECK=${FETCH_NO_CERTCHECK:-"--no-check-certificate "}
 
 ##############################################################################
 # Parsing command line parameters

--- a/summon-fpga-tools.sh
+++ b/summon-fpga-tools.sh
@@ -483,6 +483,8 @@ if [ ! -e ${STAMPS}/${IVERILOG}.build ]; then
     ../${IVERILOG}/configure --prefix=${PREFIX}
     log "Building ${IVERILOG}"
     make ${MAKEFLAGS}
+    # workaround - ivl makefile doesn't create this dir itself
+    mkdir -p ${PREFIX}/lib/ivl/
     install ${IVERILOG} install
     cd ..
     log "Cleaning up ${IVERILOG}"

--- a/summon-fpga-tools.sh
+++ b/summon-fpga-tools.sh
@@ -391,8 +391,6 @@ if [ ! -e build ]; then
     mkdir build
 fi
 
-
-
 if [ ${ICESTORM_EN} != 0 ] && [ ! -e ${STAMPS}/${ICESTORM}.build ]; then
     unpack ${ICESTORM}
     cd ${ICESTORM}
@@ -437,7 +435,7 @@ if [ ${ARACHNEPNR_EN} != 0 ] && [ ! -e ${STAMPS}/${ARACHNEPNR}.build ]; then
     rm -rf ${ARACHNEPNR}
 fi
 
-if [ ${NEXTPNR_EN} != 0 ] && [ ! -e ${STAMPS}/${NEXTPNR}.build ]; then
+if { [ ${NEXTPNR_ICE40_EN} != 0 ] || [ ${NEXTPNR_ECP5_EN} != 0 ]; } && [ ! -e ${STAMPS}/${NEXTPNR}.build ]; then
     unpack ${NEXTPNR}
     cd build
     log "Configuring ${NEXTPNR}"

--- a/summon-fpga-tools.sh
+++ b/summon-fpga-tools.sh
@@ -266,6 +266,8 @@ function clone {
 	fi
         log "Removing .git directory from ${NAME}-${GIT_SHA} ..."
         rm -rf .git
+        # save git SHA for later (needed for libtrellis)
+        echo ${GIT_SHA} > .git_sha
         cd ..
         log "Generating source archive for ${NAME}-${GIT_SHA} ..."
         tar cfj ${SOURCES}/${NAME}-${GIT_SHA}.tar.bz2 ${NAME}-${GIT_SHA}
@@ -404,7 +406,9 @@ if [ ! -e ${STAMPS}/${PRJTRELLIS}.build ]; then
     unpack ${PRJTRELLIS}
     cd ${PRJTRELLIS}/libtrellis
     log "Configuring ${PRJTRELLIS}"
-    cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} .
+    # need to set CURRENT_GIT_VERSION or libtrellis will try and fail
+    # to detect the git revision (the .git directory is deleted before archiving)
+    cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCURRENT_GIT_VERSION=$(< ../.git_sha) .
     log "Building ${PRJTRELLIS}"
     make ${MAKEFLAGS}
     install ${PRJTRELLIS} install


### PR DESCRIPTION
Fixes the build error:

```
Make Error at CMakeLists.txt:150 (add_executable):
  Cannot find source file:

    /summon-fpga-tools/prjtrellis-f6922699dcb44799fe72a861e19e93cbe235c400/libtrellis/generated/version.cpp
```
Before: https://circleci.com/gh/edbordin/summon-docker-fpga-tools/6
After: https://circleci.com/gh/edbordin/summon-docker-fpga-tools/7

edit: The second build failed for an unrelated reason - it got through building libtrellis no problems. But I understand if you'd like to test it yourself